### PR TITLE
Auto add ExtractGd import

### DIFF
--- a/as_gd_res_derive/src/lib.rs
+++ b/as_gd_res_derive/src/lib.rs
@@ -148,6 +148,7 @@ fn expand_as_gd_res(mut input: DeriveInput) -> proc_macro2::TokenStream {
                 impl ::as_gd_res::ExtractGd for #res_name {
                     type Extracted = #name;
                     fn extract(&self) -> Self::Extracted {
+                        use ::as_gd_res::ExtractGd;
                         Self::Extracted {
                             #(#extracts)*
                         }

--- a/as_gd_res_derive/src/tests.rs
+++ b/as_gd_res_derive/src/tests.rs
@@ -60,6 +60,7 @@ fn test_simple() {
       impl ::as_gd_res::ExtractGd for SimpleStructParamsResource {
           type Extracted = SimpleStructParams;
           fn extract(&self) -> Self::Extracted {
+              use ::as_gd_res::ExtractGd;
               Self::Extracted {
                   a: self.a.extract(),
                   b: self.b.extract(),
@@ -114,6 +115,7 @@ fn test_2() {
             impl ::as_gd_res::ExtractGd for DropParams2Resource {
                 type Extracted = DropParams2;
                 fn extract(&self) -> Self::Extracted {
+                    use ::as_gd_res::ExtractGd;
                     Self::Extracted {
                         total_value: self.total_value.extract(),
                         max_value_per_coin: self.max_value_per_coin.extract(),
@@ -194,6 +196,7 @@ fn test_attr_pass_through() {
       impl ::as_gd_res::ExtractGd for DropParams2Resource {
           type Extracted = DropParams2;
           fn extract(&self) -> Self::Extracted {
+              use ::as_gd_res::ExtractGd;
               Self::Extracted {
                   total_value: self.total_value.extract(),
                   max_value_per_coin: self.max_value_per_coin.extract(),
@@ -351,6 +354,7 @@ fn test_complex_nested_struct() {
         impl ::as_gd_res::ExtractGd for EnemyParamsResource {
             type Extracted = EnemyParams;
             fn extract(&self) -> Self::Extracted {
+                use ::as_gd_res::ExtractGd;
                 Self::Extracted {
                     brain_params_required: self.brain_params_required.extract(),
                     brain_params_optional: self.brain_params_optional.extract(),
@@ -514,6 +518,7 @@ fn test_post_init_attr() {
     impl ::as_gd_res::ExtractGd for JumpParamsResource {
         type Extracted = JumpParams;
         fn extract(&self) -> Self::Extracted {
+            use ::as_gd_res::ExtractGd;
             Self::Extracted {
                 height: self.height.extract(),
                 time_up: self.time_up.extract(),


### PR DESCRIPTION
## Summary
- import `ExtractGd` inside the generated `extract` method
- add expected `use` lines in derive macro tests

## Testing
- `cargo test -p as_gd_res_derive -- --nocapture`

------
https://chatgpt.com/codex/tasks/task_e_68448afe61b08323b558575ccb7c7e1e