### PR TITLE
Fix resource output CI failing by removing extra Xvfb

### DIFF
--- a/.github/workflows/resource_output_test.yml
+++ b/.github/workflows/resource_output_test.yml
@@ -22,11 +22,6 @@ jobs:
       - name: Install dependencies
         run: sudo apt-get update && sudo apt-get install -y xvfb
 
-      - name: Set up virtual display
-        run: |
-          export DISPLAY=:99
-          Xvfb :99 -screen 0 1024x768x24 &
-
       - name: Build extension
         run: cargo build
         

--- a/codex_scripts/test_resource_extract.sh
+++ b/codex_scripts/test_resource_extract.sh
@@ -11,9 +11,9 @@ if [ -z "${GODOT_BIN:-}" ]; then
 fi
 
 # Preload plugin script classes by running the editor once
-xvfb-run "$GODOT_BIN" --headless --editor --path "$REPO_ROOT/resource_test_godot_project" --quit
+xvfb-run -a "$GODOT_BIN" --headless --editor --path "$REPO_ROOT/resource_test_godot_project" --quit
 
-xvfb-run "$GODOT_BIN" --headless --path "$REPO_ROOT/resource_test_godot_project" test_scene.tscn > "$OUTPUT"
+xvfb-run -a "$GODOT_BIN" --headless --path "$REPO_ROOT/resource_test_godot_project" test_scene.tscn > "$OUTPUT"
 awk '/--- Resource Extract Test ---/{flag=1;next} flag' "$OUTPUT" > "$OUTPUT.trimmed"
 # remove trailing newline to match expected file
 truncate -s -1 "$OUTPUT.trimmed"


### PR DESCRIPTION
## Summary
- remove `Set up virtual display` step from resource output test workflow

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_6849c7f0a4dc832397a4f6f0991a36f5