### PR TITLE
Upgrade to Rust 2024 edition

### DIFF
--- a/as_gd_res/Cargo.toml
+++ b/as_gd_res/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "as_gd_res"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/as_gd_res_derive/Cargo.toml
+++ b/as_gd_res_derive/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "as_gd_res_derive"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/as_simple_gd_enum_derive/Cargo.toml
+++ b/as_simple_gd_enum_derive/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "as_simple_gd_enum_derive"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/resource_test_rust/Cargo.toml
+++ b/resource_test_rust/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "resource_test_rust"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 
 [lib]
 crate-type = ["cdylib"]


### PR DESCRIPTION
## Summary
- update all crates to use Rust 2024 edition

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_6849d89e90508323a6e61a7fd25e2787